### PR TITLE
Decompose infrastructure stacks and change DynamoDB schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,52 @@
 # cloudformation-cross-account-outputs
 
-## Usage
-
-### Deploy the infrastructure
+## Deploy the infrastructure
 
 In the AWS account that you want other accounts to emit CloudFormation outputs
 to
+
 1. Create a DynamoDB table called `cloudformation-stack-emissions`
    * This can be done by deploying the [`cloudformation-stack-emissions-dynamodb.yml`](cloudformation-stack-emissions-dynamodb.yml)
      CloudFormation template, creating the table in the web console or on the command line
-2. Deploy the CloudFormation template [`cloudformation-sns-emission-consumer.yml`](cloudformation-sns-emission-consumer.yml)
-   which will create
-   * An SNS Topic and Topic Policy to which other accounts will emit events to
-   * A Lambda function that will subscribe to that SNS Topic and an IAM Role that
-     the Lambda function will run as
+2. Deploy the CloudFormation template [`cloudformation-sns-emission-consumer-role.yml`](cloudformation-sns-emission-consumer-role.yml)
+   in a single region which will create an IAM Role used by the Lambda function
+3. Deploy the CloudFormation template [`cloudformation-sns-emission-consumer.yml`](cloudformation-sns-emission-consumer.yml)
+   in every region that you need to receive CloudFormation outputs in. Since
+   CloudFormation custom resources can only emit to SNS topics in the same
+   region, a separate SNS topic must be deployed in every region that you use.
+   This stack creates
+   * An SNS Topic to which other accounts will emit events to and Topic Policy
+   * A Lambda function subscribed to that SNS Topic
 
-### Emit outputs from a CloudFormation template
+## Emit outputs from a CloudFormation template
 
 Create a CloudFormation template containing
 * A [CloudFormation Custom Resource](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cfn-customresource.html)
   with the following properties
   * `ServiceToken` : The SNS ARN of the SNS topic you created when deploying the
     infrastructure
-  * `category` : This optional property will set the `category` value of the item
-    stored in the DynamoDB table. This will be the [sort key](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.CoreComponents.html#HowItWorks.CoreComponents.PrimaryKey)
-    which combined with the AWS account ID stored in the `aws-account-id` attribute
-    in the table make up the composite primary key. If `category` is not set in
-     the CloudFormation custom resource, a value of `general` will be used
   * An arbitrary number of additional key value pairs. In the example below
     there's a single key value pair with a key of `exampleKey` and value of
     `Example Value`
 
-#### Example CloudFormation template
+Note : You may want to constrain users from deploying this template in regions
+where you've not deployed an [SNS topic](cloudformation-sns-emission-consumer-topic.yml)
+to receive stack emissions. One way to do this is [with a region Mapping](https://gist.github.com/gene1wood/ae2b77a424d220f2d0605cb8637baa33)
+
+### Example CloudFormation template
 
 ```yaml
 AWSTemplateFormatVersion: 2010-09-09
-Parameters:
-  SNSArnForPublishingTo:
-    Type: String
-    Default: arn:aws:sns:us-west-2:656532927350:cloudformation-stack-emissions
-    Description: The ARN of the SNS Topic to publish an event to
 Resources:
   PublishTestToSNS:
     Type: Custom::PublishIAMRoleArnsToSNS
     Version: '1.0'
     Properties:
-      ServiceToken: !Ref SNSArnForPublishingTo
-      category: testing
+      ServiceToken: !Join [ ':', [ 'arn:aws:sns', !Ref 'AWS::Region', '012345678901', 'cloudformation-stack-emissions' ] ]
       exampleKey: Example Value
 ```
 
-### Fetch emitted outputs
+## Fetch emitted outputs
 
 You can fetch data from the DynamoDB table with the aws command line. To fetch
 the `exampleKey` value for all emissions in account `012345678901` query like
@@ -60,19 +56,31 @@ this
 aws dynamodb query --table-name cloudformation-stack-emissions \
   --expression-attribute-names '{"#a": "aws-account-id"}' \
   --expression-attribute-values '{":i": {"S": "012345678901"}}' \
-  --key-condition-expression "#a = :i"` \
+  --key-condition-expression "#a = :i" \
   --projection-expression exampleKey \
   --output text --query 'Items[].exampleKey.S'
 ```
 
-#### DynamoDB Schema
+### Automatically added attributes
+
+The following attributes are always set
+* `aws-account-id` : The AWS account ID in which the CloudFormation stack was
+  deployed
+* `stack-id` : The GUID of the CloudFormation stack
+
+The following attributes are set if they aren't passed in the `Properties` of
+the CloudFormation stack
+* `region` : The AWS region in which the CouldFormation stack was deployed
+* `stack-name` : The name of the CloudFormation stack
+* `last-updated` : The datetime that the record was last updated in UTC time
+
+## DynamoDB Schema
 
 * Table name : `cloudformation-stack-emissions`
 * Partition key : `aws-account-id` which contains the [AWS Account ID](https://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html)
   of the AWS account that contains the CloudFormation stack which is emitting
   data
-* Sort key : Defined by each stack with a [Resource Property](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources.html)
-  called `category`.
+* Sort key : `stack-id` which contains the CloudFormation stack's GUID.
 * Attributes : All additional Resource Properties of the CloudFormation Custom
   Resource are inserted into a DynamoDB Item as attributes (key value pairs)
   

--- a/cloudformation-sns-emission-consumer-role.yml
+++ b/cloudformation-sns-emission-consumer-role.yml
@@ -1,0 +1,48 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: IAM Role used by CloudFormation SNS emission consumer Lambda functions
+Metadata:
+  Source: https://github.com/mozilla/cloudformation-cross-account-outputs
+Mappings:
+  Variables:
+    DynamoDBTable:
+      Name: cloudformation-stack-emissions
+      Region: us-west-2
+    IAMRole:
+      Name: cloudformation-sns-emission-consumer
+Resources:
+  ProcessCloudFormationSNSEmissionLambdaIAMRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !FindInMap [ Variables, IAMRole, Name ]
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Policies:
+        - PolicyName: AllowLambdaLogging
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              -
+                Effect: Allow
+                Action:
+                  - logs:*
+                  - iam:ListRoles
+                Resource: '*'
+        - PolicyName: AllowDynamoDB
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              -
+                Effect: Allow
+                Action:
+                  - dynamodb:CreateTable
+                  - dynamodb:DescribeTable
+                  - dynamodb:PutItem
+                  - dynamodb:DeleteItem
+                Resource: !Join [ '', [ 'arn:aws:dynamodb:', !FindInMap [ Variables, DynamoDBTable, Region ], ':', !Ref 'AWS::AccountId', ':table/', !FindInMap [ Variables, DynamoDBTable, Name ]]]

--- a/cloudformation-sns-emission-consumer.yml
+++ b/cloudformation-sns-emission-consumer.yml
@@ -1,11 +1,14 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: Lambda function that processes Custom Resource SNS emissions, storing them in DynamoDB
+Description: SNS topic that receives CloudFormation Custom Resource SNS emissions and a Lambda function that processes those emissions, storing them in DynamoDB
 Metadata:
   Source: https://github.com/mozilla/cloudformation-cross-account-outputs
 Mappings:
   Variables:
     DynamoDBTable:
       Name: cloudformation-stack-emissions
+      Region: us-west-2
+    IAMRole:
+      Name: cloudformation-sns-emission-consumer
 Resources:
   CloudFormationEmissionSNSTopic:
     Type: AWS::SNS::Topic
@@ -26,41 +29,6 @@ Resources:
             Effect: Allow
       Topics:
       - !Ref CloudFormationEmissionSNSTopic
-  ProcessCloudFormationSNSEmissionLambdaIAMRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service:
-            - lambda.amazonaws.com
-          Action:
-          - sts:AssumeRole
-      Policies:
-        - PolicyName: AllowLambdaLogging
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              -
-                Effect: Allow
-                Action:
-                  - logs:*
-                  - iam:ListRoles
-                Resource: '*'
-        - PolicyName: AllowDynamoDB
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              -
-                Effect: Allow
-                Action:
-                  - dynamodb:CreateTable
-                  - dynamodb:DescribeTable
-                  - dynamodb:PutItem
-                  - dynamodb:DeleteItem
-                Resource: !Join [ '', [ 'arn:aws:dynamodb:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':table/', !FindInMap [ Variables, DynamoDBTable, Name ]]]
   ProcessCloudFormationSNSEmissionLambdaFunction:
     Type: AWS::Lambda::Function
     Properties:
@@ -71,18 +39,21 @@ Resources:
             import boto3, secrets, string, time, traceback, json
             from datetime import datetime
 
-            ITEM_CATEGORY_KEY = 'category'
             LAST_UPDATED_KEY = 'last-updated'
-            AWS_ACCOUNT_KEY = 'aws-account-id'
-            GENERAL_ITEM_CATEGORY = 'general'
+            ACCOUNT_ID_KEY = 'aws-account-id'
+            STACK_ID_KEY = 'stack-id'
             TABLE_NAME = (
                 'cloudformation-stack-emissions'
                 if '${DynamoDBTableName}'.startswith('$' + '{')
                 else '${DynamoDBTableName}')
+            TABLE_REGION = (
+                'us-west-2'
+                if '${DynamoDBTableRegion}'.startswith('$' + '{')
+                else '${DynamoDBTableRegion}')
 
 
             def get_table_status(table_name):
-                client = boto3.client('dynamodb')
+                client = boto3.client('dynamodb', region_name=TABLE_REGION)
                 try:
                     while True:
                         response = client.describe_table(TableName=table_name)
@@ -97,44 +68,29 @@ Resources:
 
             def update_table(message):
                 item = dict(message['ResourceProperties'])
-                # Force stacks to only be able to update items in their partition
-                item[AWS_ACCOUNT_KEY] = message['StackId'].split(':')[4]
-                # Case-insensitive match to "category". If ResourceProperties has
-                # "Category" and "category" keys, this is non-deterministic
-                item[ITEM_CATEGORY_KEY] = next(
-                    (iter([item[x] for x in item if x.lower() == ITEM_CATEGORY_KEY])),
-                    GENERAL_ITEM_CATEGORY)
+                del(item['ServiceToken'])
                 stack_path = message['StackId'].split(':')[5]
+                stack_guid = stack_path.split('/')[2]
+
+                # Force stacks to only be able to update items that they created
+                item[ACCOUNT_ID_KEY] = message['StackId'].split(':')[4]
+                item[STACK_ID_KEY] = stack_guid
+
                 item.setdefault('stack-name', stack_path.split('/')[1])
-                item.setdefault('stack-guid', stack_path.split('/')[2])
+                item.setdefault('region', message['StackId'].split(':')[3])
                 item.setdefault(LAST_UPDATED_KEY, datetime.utcnow().isoformat() + 'Z')
 
-                dynamodb = boto3.resource('dynamodb')
+                dynamodb = boto3.resource('dynamodb', region_name=TABLE_REGION)
 
                 if message['RequestType'] == 'Delete':
                     table = dynamodb.Table(TABLE_NAME)
                     table.delete_item(
-                        Key={AWS_ACCOUNT_KEY: item[AWS_ACCOUNT_KEY],
-                             ITEM_CATEGORY_KEY: item[ITEM_CATEGORY_KEY]})
+                        Key={ACCOUNT_ID_KEY: item[ACCOUNT_ID_KEY],
+                             STACK_ID_KEY: item[STACK_ID_KEY]})
                     # We don't check to see if the table is now empty and can be deleted
                     # because there's no cheap or easy way to determine if a table is empty
                     # using either ItemCount or Scan
                 elif message['RequestType'] in ['Create', 'Update']:
-                    while not get_table_status(TABLE_NAME):
-                        # TODO : Should this be moved out into the CloudFormation template?
-                        dynamodb.create_table(
-                            AttributeDefinitions=[
-                                {'AttributeName': AWS_ACCOUNT_KEY, 'AttributeType': 'S'},
-                                {'AttributeName': ITEM_CATEGORY_KEY,
-                                 'AttributeType': 'S'}],
-                            TableName=TABLE_NAME,
-                            KeySchema=[{'AttributeName': AWS_ACCOUNT_KEY,
-                                        'KeyType': 'HASH'},
-                                       {'AttributeName': ITEM_CATEGORY_KEY,
-                                        'KeyType': 'RANGE'}],
-                            ProvisionedThroughput={
-                                'ReadCapacityUnits': 1, 'WriteCapacityUnits': 1})
-                        time.sleep(5)
                     table = dynamodb.Table(TABLE_NAME)
                     table.put_item(Item=item)
 
@@ -160,9 +116,10 @@ Resources:
                     message, context, status, {},
                     "ProcessCloudFormationSNSEmission-%s" % physical_id)
           - DynamoDBTableName: !FindInMap [ Variables, DynamoDBTable, Name ]
+            DynamoDBTableRegion: !FindInMap [ Variables, DynamoDBTable, Region ]
       Handler: index.handler
       Runtime: python3.6
-      Role: !GetAtt ProcessCloudFormationSNSEmissionLambdaIAMRole.Arn
+      Role: !Join [ '', [ 'arn:aws:iam::', !Ref 'AWS::AccountId', ':role/', !FindInMap [ Variables, IAMRole, Name ] ]]
       Timeout: 20
   ProcessCloudFormationSNSEmissionLambdaFunctionPermission:
     Type: AWS::Lambda::Permission

--- a/cloudformation-stack-emissions-dynamodb.yml
+++ b/cloudformation-stack-emissions-dynamodb.yml
@@ -6,20 +6,21 @@ Mappings:
   Variables:
     DynamoDBTable:
       Name: cloudformation-stack-emissions
+      AccountIdKey: aws-account-id
+      StackIdKey: stack-id
 Resources:
   DynamoDBTable:
     Type: AWS::DynamoDB::Table
     Properties:
       AttributeDefinitions:
-        - AttributeName: aws-account-id
+        - AttributeName: !FindInMap [ Variables, DynamoDBTable, AccountIdKey ]
           AttributeType: S
-        - AttributeName: category
+        - AttributeName: !FindInMap [ Variables, DynamoDBTable, StackIdKey ]
           AttributeType: S
       BillingMode: PAY_PER_REQUEST
       KeySchema:
         - KeyType: HASH
-          AttributeName: aws-account-id
+          AttributeName: !FindInMap [ Variables, DynamoDBTable, AccountIdKey ]
         - KeyType: RANGE
-          AttributeName: category
+          AttributeName: !FindInMap [ Variables, DynamoDBTable, StackIdKey ]
       TableName: !FindInMap [ Variables, DynamoDBTable, Name ]
-

--- a/tests/test_emission.yml
+++ b/tests/test_emission.yml
@@ -1,16 +1,27 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Test emission to SNS
-Parameters:
-  SNSArnForPublishingTo:
-    Type: String
-    Default: arn:aws:sns:us-west-2:656532927350:cloudformation-stack-emissions
-    Description: The ARN of the SNS Topic to publish an event to
+Mappings:
+  TheRegionYouAreDeployingIn:
+    us-west-2:
+      WhatIsThisMapping: This constrains the regions in which you can deploy this template to only the regions listed in this mapping. This, for example, prevents deloying in ap-south-1
+      IsNotSupportedPleaseUseADifferentRegion: True
+    us-east-1:
+      WhatIsThisMapping: ''
+      IsNotSupportedPleaseUseADifferentRegion: True
+    us-west-1:
+      WhatIsThisMapping: ''
+      IsNotSupportedPleaseUseADifferentRegion: True
+    eu-west-1:
+      WhatIsThisMapping: ''
+      IsNotSupportedPleaseUseADifferentRegion: True
+Conditions:
+  RunningInAllowedRegion: !Equals [ !FindInMap [ TheRegionYouAreDeployingIn, !Ref 'AWS::Region', IsNotSupportedPleaseUseADifferentRegion ] , True ]
 Resources:
   PublishTestToSNS:
     Type: Custom::PublishIAMRoleArnsToSNS
     Version: '1.0'
     Properties:
-      ServiceToken: !Ref SNSArnForPublishingTo
+      ServiceToken: !Join [ ':', [ 'arn:aws:sns', !Ref 'AWS::Region', '656532927350', 'cloudformation-stack-emissions' ] ]
       category: testing
       mountain: Mount Foraker
       state: Alaska


### PR DESCRIPTION
The original design did not account for emitting stacks in regions
other than the region in which the infrastructure was deployed.

This is fixed by
* Separating the Lambda function IAM role into it's own stack
* Moving to a model where the "consumer" stack which contains the
  SNS topic and Lambda function are deployed in each region that
  you want to support receiving emissions in

The DynamoDB schema was also changed to prevent multiple stacks
in the same account from overwriting each other. Originally this
was intentional in the design but after working through trying to
use it, it became apparent that it wasn't ideal.

The new schema continues to use the account id as the partition key
but changes the sort key from "category" to the GUID of the
CloudFormation stack that emitted the record.

Additional cleanup includes
* Deleting the ServiceToken attribute so it's not stored in the DyanmoDB
  record
* Adding an attribute with the region of the emitting stack
* Removing the table provsioning from the Lambda function as this is
  handled in the dedicated DynamoDB CloudFormation template
* Added documentation and examples of how to constrain emitting stacks
  to only regions in which you've deployed the consuming infrastructure

Fixes #5