### PR TITLE
Fix stack updates causing deletion

### DIFF
--- a/cloudformation-sns-emission-consumer.yml
+++ b/cloudformation-sns-emission-consumer.yml
@@ -109,12 +109,15 @@ Resources:
                 else:
                     print('Custom resource succeeded.')
                     status = cfnresponse.SUCCESS
-                physical_id = ''.join(
-                    secrets.choice(string.ascii_uppercase + string.digits) for _ in
-                    range(13))
-                cfnresponse.send(
-                    message, context, status, {},
-                    "ProcessCloudFormationSNSEmission-%s" % physical_id)
+                if 'PhysicalResourceId' in message:
+                    physical_id = message['PhysicalResourceId']
+                else:
+                    random_string = ''.join(
+                        secrets.choice(string.ascii_uppercase + string.digits)
+                        for _ in range(13))
+                    physical_id = "ProcessCloudFormationSNSEmission-{}".format(
+                        random_string)
+                cfnresponse.send(message, context, status, {}, physical_id)
           - DynamoDBTableName: !FindInMap [ Variables, DynamoDBTable, Name ]
             DynamoDBTableRegion: !FindInMap [ Variables, DynamoDBTable, Region ]
       Handler: index.handler

--- a/process_cloudformation_sns_emission_lambda_function/__init__.py
+++ b/process_cloudformation_sns_emission_lambda_function/__init__.py
@@ -72,9 +72,12 @@ def handler(event, context):
     else:
         print('Custom resource succeeded.')
         status = cfnresponse.SUCCESS
-    physical_id = ''.join(
-        secrets.choice(string.ascii_uppercase + string.digits) for _ in
-        range(13))
-    cfnresponse.send(
-        message, context, status, {},
-        "ProcessCloudFormationSNSEmission-%s" % physical_id)
+    if 'PhysicalResourceId' in message:
+        physical_id = message['PhysicalResourceId']
+    else:
+        random_string = ''.join(
+            secrets.choice(string.ascii_uppercase + string.digits)
+            for _ in range(13))
+        physical_id = "ProcessCloudFormationSNSEmission-{}".format(
+            random_string)
+    cfnresponse.send(message, context, status, {}, physical_id)

--- a/tests/test_emission.yml
+++ b/tests/test_emission.yml
@@ -1,5 +1,10 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Test emission to SNS
+Parameters:
+  ADynamicValue:
+    Type: String
+    Default: This is a default value
+    Description: A dynamic value to test stack updates
 Mappings:
   TheRegionYouAreDeployingIn:
     us-west-2:
@@ -25,6 +30,7 @@ Resources:
       category: testing
       mountain: Mount Foraker
       state: Alaska
+      MyDynamicString: !Ref ADynamicValue
       MyNumber: 1.234
       MyMap:
         MapVal1: baz


### PR DESCRIPTION
Previously, the PhysicalResourceId was generated each time the Lambda function
was called. This was causing stack updates to result in
* update event
* response back to AWS with a new PhysicalResourceId
* delete event
* deletion of the record in DynamoDB

This is because AWS checks to see if the PhysicalResourceId has changed and if
it has it triggers a Delete : https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cfn-customresource.html#w2ab1c21c10c51c19c19

Now the Lambda function checks for the presense of a PhysicalResourceId in the
message and uses that if it's present instead of generating one