### PR TITLE
Change DynamoDB Schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ROOT_DIR	:= $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 PARENTDIR       := $(realpath ../)
-AWS_REGION = us-west-2
+AWS_DEFAULT_REGION = us-west-2
 S3_BUCKET_NAME  := public.us-west-2.infosec.mozilla.org
 S3_BUCKET_TEMPLATE_PATH	:= cloudformation-cross-account-outputs/cf
 S3_BUCKET_TEMPLATE_URI	:= s3://$(S3_BUCKET_NAME)/$(S3_BUCKET_TEMPLATE_PATH)
@@ -17,16 +17,54 @@ cfn-lint: ## Verify the CloudFormation templates pass linting tests
 
 .PHONY: upload-templates
 upload-templates:
-	AWS_REGION=$(AWS_REGION) aws s3 sync cloudformation/ $(S3_BUCKET_TEMPLATE_URI) --exclude="*" --include="*.yml"
+	AWS_DEFAULT_REGION=$(AWS_DEFAULT_REGION) aws s3 sync cloudformation/ $(S3_BUCKET_TEMPLATE_URI) --exclude="*" --include="*.yml"
 
 .PHONY: create-stacks
-create-stacks:
-	AWS_REGION=us-west-2 aws cloudformation create-stack --stack-name cloudformation-stack-emissions-dynamodb \
-	  --template-url $(HTTP_BUCKET_TEMPLATE_URI)/cloudformation-stack-emissions-dynamodb.yml
-	AWS_REGION=us-west-2 aws cloudformation create-stack --stack-name cloudformation-sns-emission-consumer-role \
+create-stacks: create-consumer-stacks create-role-stack create-dynamodb-stack
+
+.PHONY: create-consumer-stacks
+create-consumer-stacks:
+	AWS_DEFAULT_REGION=us-west-2 aws cloudformation create-stack --stack-name cloudformation-sns-emission-consumer-us-west-2 \
+	  --template-url $(HTTP_BUCKET_TEMPLATE_URI)/cloudformation-sns-emission-consumer.yml
+	AWS_DEFAULT_REGION=us-east-1 aws cloudformation create-stack --stack-name cloudformation-sns-emission-consumer-us-east-1 \
+	  --template-url $(HTTP_BUCKET_TEMPLATE_URI)/cloudformation-sns-emission-consumer.yml
+	AWS_DEFAULT_REGION=us-west-1 aws cloudformation create-stack --stack-name cloudformation-sns-emission-consumer-us-west-1 \
+	  --template-url $(HTTP_BUCKET_TEMPLATE_URI)/cloudformation-sns-emission-consumer.yml
+	AWS_DEFAULT_REGION=eu-west-1 aws cloudformation create-stack --stack-name cloudformation-sns-emission-consumer-eu-west-1 \
+	  --template-url $(HTTP_BUCKET_TEMPLATE_URI)/cloudformation-sns-emission-consumer.yml
+
+.PHONY: create-role-stack
+create-role-stack:
+	AWS_DEFAULT_REGION=$(AWS_DEFAULT_REGION) aws cloudformation create-stack --stack-name cloudformation-sns-emission-consumer-role \
 	  --capabilities CAPABILITY_IAM \
 	  --template-url $(HTTP_BUCKET_TEMPLATE_URI)/cloudformation-sns-emission-consumer-role.yml
-	AWS_REGION=us-west-2 aws cloudformation create-stack --stack-name cloudformation-sns-emission-consumer-us-west-2 \
+
+.PHONY: create-dynamodb-stack
+create-dynamodb-stack:
+	AWS_DEFAULT_REGION=$(AWS_DEFAULT_REGION) aws cloudformation create-stack --stack-name cloudformation-stack-emissions-dynamodb \
+	  --template-url $(HTTP_BUCKET_TEMPLATE_URI)/cloudformation-stack-emissions-dynamodb.yml
+
+.PHONY: update-stacks
+update-stacks: update-consumer-stacks update-role-stack update-dynamodb-stack
+
+.PHONY: update-consumer-stacks
+update-consumer-stacks:
+	AWS_DEFAULT_REGION=us-west-2 aws cloudformation update-stack --stack-name cloudformation-sns-emission-consumer-us-west-2 \
 	  --template-url $(HTTP_BUCKET_TEMPLATE_URI)/cloudformation-sns-emission-consumer.yml
-	AWS_REGION=us-east-1 aws cloudformation create-stack --stack-name cloudformation-sns-emission-consumer-us-east-1 \
+	AWS_DEFAULT_REGION=us-east-1 aws cloudformation update-stack --stack-name cloudformation-sns-emission-consumer-us-east-1 \
 	  --template-url $(HTTP_BUCKET_TEMPLATE_URI)/cloudformation-sns-emission-consumer.yml
+	AWS_DEFAULT_REGION=us-west-1 aws cloudformation update-stack --stack-name cloudformation-sns-emission-consumer-us-west-1 \
+	  --template-url $(HTTP_BUCKET_TEMPLATE_URI)/cloudformation-sns-emission-consumer.yml
+	AWS_DEFAULT_REGION=eu-west-1 aws cloudformation update-stack --stack-name cloudformation-sns-emission-consumer-eu-west-1 \
+	  --template-url $(HTTP_BUCKET_TEMPLATE_URI)/cloudformation-sns-emission-consumer.yml
+
+.PHONY: update-role-stack
+update-role-stack:
+	AWS_DEFAULT_REGION=$(AWS_DEFAULT_REGION) aws cloudformation update-stack --stack-name cloudformation-sns-emission-consumer-role \
+	  --capabilities CAPABILITY_IAM \
+	  --template-url $(HTTP_BUCKET_TEMPLATE_URI)/cloudformation-sns-emission-consumer-role.yml
+
+.PHONY: update-dynamodb-stack
+update-dynamodb-stack:
+	AWS_DEFAULT_REGION=$(AWS_DEFAULT_REGION) aws cloudformation update-stack --stack-name cloudformation-stack-emissions-dynamodb \
+	  --template-url $(HTTP_BUCKET_TEMPLATE_URI)/cloudformation-stack-emissions-dynamodb.yml

--- a/cloudformation/cloudformation-sns-emission-consumer.yml
+++ b/cloudformation/cloudformation-sns-emission-consumer.yml
@@ -2,6 +2,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: SNS topic that receives CloudFormation Custom Resource SNS emissions and a Lambda function that processes those emissions, storing them in DynamoDB
 Metadata:
   Source: https://github.com/mozilla/cloudformation-cross-account-outputs
+  TemplateVersion: 3.0.0
 Mappings:
   Variables:
     DynamoDBTable:
@@ -42,6 +43,7 @@ Resources:
             LAST_UPDATED_KEY = 'last-updated'
             ACCOUNT_ID_KEY = 'aws-account-id'
             STACK_ID_KEY = 'stack-id'
+            LOGICAL_RESOURCE_ID_KEY = 'logical-resource-id'
             TABLE_NAME = (
                 'cloudformation-stack-emissions'
                 if '${DynamoDBTableName}'.startswith('$' + '{')
@@ -72,10 +74,12 @@ Resources:
                 stack_path = message['StackId'].split(':')[5]
                 stack_guid = stack_path.split('/')[2]
 
-                # Force stacks to only be able to update items that they created
-                item[ACCOUNT_ID_KEY] = message['StackId'].split(':')[4]
+                # Force resources in stacks to only be able to update items that they
+                # created
                 item[STACK_ID_KEY] = stack_guid
+                item[LOGICAL_RESOURCE_ID_KEY] = message['LogicalResourceId']
 
+                item[ACCOUNT_ID_KEY] = message['StackId'].split(':')[4]
                 item.setdefault('stack-name', stack_path.split('/')[1])
                 item.setdefault('region', message['StackId'].split(':')[3])
                 item.setdefault(LAST_UPDATED_KEY, datetime.utcnow().isoformat() + 'Z')
@@ -85,8 +89,8 @@ Resources:
                 if message['RequestType'] == 'Delete':
                     table = dynamodb.Table(TABLE_NAME)
                     table.delete_item(
-                        Key={ACCOUNT_ID_KEY: item[ACCOUNT_ID_KEY],
-                             STACK_ID_KEY: item[STACK_ID_KEY]})
+                        Key={STACK_ID_KEY: item[STACK_ID_KEY],
+                             LOGICAL_RESOURCE_ID_KEY: item[LOGICAL_RESOURCE_ID_KEY]})
                     # We don't check to see if the table is now empty and can be deleted
                     # because there's no cheap or easy way to determine if a table is empty
                     # using either ItemCount or Scan

--- a/cloudformation/cloudformation-stack-emissions-dynamodb.yml
+++ b/cloudformation/cloudformation-stack-emissions-dynamodb.yml
@@ -2,25 +2,26 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: DynamoDB used to store CloudFormation stack emissions
 Metadata:
   Source: https://github.com/mozilla/cloudformation-cross-account-outputs
+  TemplateVersion: 3.0.0
 Mappings:
   Variables:
     DynamoDBTable:
       Name: cloudformation-stack-emissions
-      AccountIdKey: aws-account-id
+      LogicalResourceIdKey: logical-resource-id
       StackIdKey: stack-id
 Resources:
   DynamoDBTable:
     Type: AWS::DynamoDB::Table
     Properties:
       AttributeDefinitions:
-        - AttributeName: !FindInMap [ Variables, DynamoDBTable, AccountIdKey ]
-          AttributeType: S
         - AttributeName: !FindInMap [ Variables, DynamoDBTable, StackIdKey ]
+          AttributeType: S
+        - AttributeName: !FindInMap [ Variables, DynamoDBTable, LogicalResourceIdKey ]
           AttributeType: S
       BillingMode: PAY_PER_REQUEST
       KeySchema:
         - KeyType: HASH
-          AttributeName: !FindInMap [ Variables, DynamoDBTable, AccountIdKey ]
-        - KeyType: RANGE
           AttributeName: !FindInMap [ Variables, DynamoDBTable, StackIdKey ]
+        - KeyType: RANGE
+          AttributeName: !FindInMap [ Variables, DynamoDBTable, LogicalResourceIdKey ]
       TableName: !FindInMap [ Variables, DynamoDBTable, Name ]


### PR DESCRIPTION
This changes from using
* partition key : account id
* sort key : stack id

to

* partition key : stack id
* sort key : logical resource id

so that each resource within a given CloudFormation stack has unique rights to edit/delete the attributes it sets. This allows a stack to have multiple resources that emit data and for a single stack to produce multiple records in DynamoDB