### PR TITLE
Update db schema and add category field back in

### DIFF
--- a/cloudformation/cloudformation-sns-emission-consumer.yml
+++ b/cloudformation/cloudformation-sns-emission-consumer.yml
@@ -2,7 +2,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: SNS topic that receives CloudFormation Custom Resource SNS emissions and a Lambda function that processes those emissions, storing them in DynamoDB
 Metadata:
   Source: https://github.com/mozilla/cloudformation-cross-account-outputs
-  TemplateVersion: 3.0.0
+  TemplateVersion: 4.0.0
 Mappings:
   Variables:
     DynamoDBTable:
@@ -37,13 +37,17 @@ Resources:
         ZipFile: !Sub
           - |
             import cfnresponse
-            import boto3, secrets, string, time, traceback, json
+            import boto3, secrets, string, traceback, json
             from datetime import datetime
 
             LAST_UPDATED_KEY = 'last-updated'
             ACCOUNT_ID_KEY = 'aws-account-id'
             STACK_ID_KEY = 'stack-id'
             LOGICAL_RESOURCE_ID_KEY = 'logical-resource-id'
+            SORT_KEY = 'id'
+            CATEGORY_KEY = 'category'
+            GENERAL_ITEM_CATEGORY = 'general'
+
             TABLE_NAME = (
                 'cloudformation-stack-emissions'
                 if '${DynamoDBTableName}'.startswith('$' + '{')
@@ -54,20 +58,6 @@ Resources:
                 else '${DynamoDBTableRegion}')
 
 
-            def get_table_status(table_name):
-                client = boto3.client('dynamodb', region_name=TABLE_REGION)
-                try:
-                    while True:
-                        response = client.describe_table(TableName=table_name)
-                        if response['Table']['TableStatus'] in ['CREATING',
-                                                                'UPDATING', 'DELETING']:
-                            time.sleep(5)
-                            continue
-                        return response['Table']['TableStatus'] == 'ACTIVE'
-                except client.exceptions.ResourceNotFoundException:
-                    return False
-
-
             def update_table(message):
                 item = dict(message['ResourceProperties'])
                 del(item['ServiceToken'])
@@ -76,10 +66,15 @@ Resources:
 
                 # Force resources in stacks to only be able to update items that they
                 # created
+                item[ACCOUNT_ID_KEY] = message['StackId'].split(':')[4]
+                item.setdefault(CATEGORY_KEY, GENERAL_ITEM_CATEGORY)
+                item[SORT_KEY] = '{}+{}'.format(
+                    stack_guid,
+                    message['LogicalResourceId'])
+
                 item[STACK_ID_KEY] = stack_guid
                 item[LOGICAL_RESOURCE_ID_KEY] = message['LogicalResourceId']
 
-                item[ACCOUNT_ID_KEY] = message['StackId'].split(':')[4]
                 item.setdefault('stack-name', stack_path.split('/')[1])
                 item.setdefault('region', message['StackId'].split(':')[3])
                 item.setdefault(LAST_UPDATED_KEY, datetime.utcnow().isoformat() + 'Z')
@@ -89,8 +84,8 @@ Resources:
                 if message['RequestType'] == 'Delete':
                     table = dynamodb.Table(TABLE_NAME)
                     table.delete_item(
-                        Key={STACK_ID_KEY: item[STACK_ID_KEY],
-                             LOGICAL_RESOURCE_ID_KEY: item[LOGICAL_RESOURCE_ID_KEY]})
+                        Key={ACCOUNT_ID_KEY: item[ACCOUNT_ID_KEY],
+                             SORT_KEY: item[SORT_KEY]})
                     # We don't check to see if the table is now empty and can be deleted
                     # because there's no cheap or easy way to determine if a table is empty
                     # using either ItemCount or Scan

--- a/cloudformation/cloudformation-stack-emissions-dynamodb.yml
+++ b/cloudformation/cloudformation-stack-emissions-dynamodb.yml
@@ -2,26 +2,38 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: DynamoDB used to store CloudFormation stack emissions
 Metadata:
   Source: https://github.com/mozilla/cloudformation-cross-account-outputs
-  TemplateVersion: 3.0.0
+  TemplateVersion: 4.0.0
 Mappings:
   Variables:
     DynamoDBTable:
       Name: cloudformation-stack-emissions
-      LogicalResourceIdKey: logical-resource-id
-      StackIdKey: stack-id
+      SortKey: id
+      AccountIdKey: aws-account-id
+      CategoryKey: category
 Resources:
   DynamoDBTable:
     Type: AWS::DynamoDB::Table
     Properties:
       AttributeDefinitions:
-        - AttributeName: !FindInMap [ Variables, DynamoDBTable, StackIdKey ]
+        - AttributeName: !FindInMap [ Variables, DynamoDBTable, AccountIdKey ]
           AttributeType: S
-        - AttributeName: !FindInMap [ Variables, DynamoDBTable, LogicalResourceIdKey ]
+        - AttributeName: !FindInMap [ Variables, DynamoDBTable, SortKey ]
+          AttributeType: S
+        - AttributeName: !FindInMap [ Variables, DynamoDBTable, CategoryKey ]
           AttributeType: S
       BillingMode: PAY_PER_REQUEST
       KeySchema:
         - KeyType: HASH
-          AttributeName: !FindInMap [ Variables, DynamoDBTable, StackIdKey ]
+          AttributeName: !FindInMap [ Variables, DynamoDBTable, AccountIdKey ]
         - KeyType: RANGE
-          AttributeName: !FindInMap [ Variables, DynamoDBTable, LogicalResourceIdKey ]
+          AttributeName: !FindInMap [ Variables, DynamoDBTable, SortKey ]
       TableName: !FindInMap [ Variables, DynamoDBTable, Name ]
+      GlobalSecondaryIndexes:
+        - IndexName: !FindInMap [ Variables, DynamoDBTable, CategoryKey ]
+          KeySchema:
+            - KeyType: HASH
+              AttributeName: !FindInMap [ Variables, DynamoDBTable, CategoryKey ]
+            - KeyType: RANGE
+              AttributeName: !FindInMap [ Variables, DynamoDBTable, SortKey ]
+          Projection:
+            ProjectionType: ALL

--- a/tests/test_emission.yml
+++ b/tests/test_emission.yml
@@ -6,6 +6,10 @@ Parameters:
     Default: This is a default value
     Description: A dynamic value to test stack updates
 Mappings:
+  Variables:
+    SNSTarget:
+      AccountId: 656532927350
+      TopicName: cloudformation-stack-emissions
   TheRegionYouAreDeployingIn:
     us-west-2:
       WhatIsThisMapping: This constrains the regions in which you can deploy this template to only the regions listed in this mapping. This, for example, prevents deloying in ap-south-1
@@ -23,10 +27,10 @@ Conditions:
   RunningInAllowedRegion: !Equals [ !FindInMap [ TheRegionYouAreDeployingIn, !Ref 'AWS::Region', IsNotSupportedPleaseUseADifferentRegion ] , True ]
 Resources:
   PublishTestToSNS:
-    Type: Custom::PublishIAMRoleArnsToSNS
+    Type: Custom::PublishToSNS
     Version: '1.0'
     Properties:
-      ServiceToken: !Join [ ':', [ 'arn:aws:sns', !Ref 'AWS::Region', '656532927350', 'cloudformation-stack-emissions' ] ]
+      ServiceToken: !Join [ ':', [ 'arn:aws:sns', !Ref 'AWS::Region', !FindInMap [ Variables, SNSTarget, AccountId ], !FindInMap [ Variables, SNSTarget, TopicName ] ] ]
       category: testing
       mountain: Mount Foraker
       state: Alaska
@@ -46,10 +50,22 @@ Resources:
         - 5.678
       MyBoolean: True
   ASecondPublishTest:
-    Type: Custom::PublishIAMRoleArnsToSNS
+    Type: Custom::PublishToSNS
     Version: '1.0'
     Properties:
-      ServiceToken: !Join [ ':', [ 'arn:aws:sns', !Ref 'AWS::Region', '656532927350', 'cloudformation-stack-emissions' ] ]
+      ServiceToken: !Join [ ':', [ 'arn:aws:sns', !Ref 'AWS::Region', !FindInMap [ Variables, SNSTarget, AccountId ], !FindInMap [ Variables, SNSTarget, TopicName ] ] ]
       category: also-testing
       MyNumber: 4.556
-
+  AnEmissionWithNoCategory:
+    Type: Custom::PublishToSNS
+    Version: '1.0'
+    Properties:
+      ServiceToken: !Join [ ':', [ 'arn:aws:sns', !Ref 'AWS::Region', !FindInMap [ Variables, SNSTarget, AccountId ], !FindInMap [ Variables, SNSTarget, TopicName ] ] ]
+      MyNumber: 7.89
+#  ANewlyAddedEmission:
+#    Type: Custom::PublishToSNS
+#    Version: '1.0'
+#    Properties:
+#      ServiceToken: !Join [ ':', [ 'arn:aws:sns', !Ref 'AWS::Region', !FindInMap [ Variables, SNSTarget, AccountId ], !FindInMap [ Variables, SNSTarget, TopicName ] ] ]
+#      category: foo
+#      MyBoolean: False


### PR DESCRIPTION
This updates the DB schema to version 4.0.0
This changes the partition key and sort key and establishes an additional Global Secondary Index
These changes facilitate querying for either the items in a given AWS account
or the items with a given category value