### PR TITLE
Refactor the DynamoDB template to use CloudFormation parameters

### DIFF
--- a/cloudformation/cloudformation-sns-emission-consumer-role.yml
+++ b/cloudformation/cloudformation-sns-emission-consumer-role.yml
@@ -1,19 +1,40 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: IAM Role used by CloudFormation SNS emission consumer Lambda functions
+
+Parameters:
+  DynamoDBTableName: 
+    Type: String
+    Description: The name of the emission DynamoDB table
+    Default: cloudformation-stack-emissions
+    AllowedPattern: "[A-Za-z0-9._-]+"
+    ConstraintDescription: Only alphanumeric characters, dash, underscores and dot
+    MinLength: 3
+    MaxLength: 255
+
+  DynamoDBTableRegion: 
+    Type: String
+    Description: The region where the emission DynamoDB table is located
+    Default: us-west-2
+    AllowedPattern: "[a-z0-9-]+"
+    ConstraintDescription: Only lowercase letters, numbers and dashes
+
+  EmissionSNSConsumerIAMRoleName: 
+    Type: String
+    Description: The region where the emission DynamoDB table is located
+    Default: cloudformation-sns-emission-consumer
+    AllowedPattern: '[\w+=,.@-]+'
+    ConstraintDescription: Should match the role name regex
+    MinLength: 1
+    MaxLength: 64
+
 Metadata:
   Source: https://github.com/mozilla/cloudformation-cross-account-outputs
-Mappings:
-  Variables:
-    DynamoDBTable:
-      Name: cloudformation-stack-emissions
-      Region: us-west-2
-    IAMRole:
-      Name: cloudformation-sns-emission-consumer
+
 Resources:
   ProcessCloudFormationSNSEmissionLambdaIAMRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !FindInMap [ Variables, IAMRole, Name ]
+      RoleName: !Ref EmissionSNSConsumerIAMRoleName
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -45,4 +66,4 @@ Resources:
                   - dynamodb:DescribeTable
                   - dynamodb:PutItem
                   - dynamodb:DeleteItem
-                Resource: !Join [ '', [ 'arn:aws:dynamodb:', !FindInMap [ Variables, DynamoDBTable, Region ], ':', !Ref 'AWS::AccountId', ':table/', !FindInMap [ Variables, DynamoDBTable, Name ]]]
+                Resource: !Sub 'arn:aws:dynamodb:${DynamoDBTableRegion}:${AWS::AccountId}:table/${DynamoDBTableName}'

--- a/cloudformation/cloudformation-sns-emission-consumer.yml
+++ b/cloudformation/cloudformation-sns-emission-consumer.yml
@@ -1,20 +1,52 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: SNS topic that receives CloudFormation Custom Resource SNS emissions and a Lambda function that processes those emissions, storing them in DynamoDB
+
+Parameters: 
+
+  DynamoDBTableName: 
+    Type: String
+    Description: The name of the emission DynamoDB table
+    Default: cloudformation-stack-emissions
+    AllowedPattern: "[A-Za-z0-9._-]+"
+    ConstraintDescription: Only alphanumeric characters, dash, underscores and dot
+    MinLength: 3
+    MaxLength: 255
+
+  DynamoDBTableRegion: 
+    Type: String
+    Description: The region where the emission DynamoDB table is located
+    Default: us-west-2
+    AllowedPattern: "[a-z0-9-]+"
+    ConstraintDescription: Only lowercase letters, numbers and dashes
+
+  EmissionSNSTopicName: 
+    Type: String
+    Description: The region where the emission DynamoDB table is located
+    Default: cloudformation-stack-emissions
+    AllowedPattern: "[A-Za-z0-9_-]+"
+    ConstraintDescription: Only alphanumeric characters, dash and underscores
+    MinLength: 1
+    MaxLength: 256
+
+  EmissionSNSConsumerIAMRoleName: 
+    Type: String
+    Description: The region where the emission DynamoDB table is located
+    Default: cloudformation-sns-emission-consumer
+    AllowedPattern: '[\w+=,.@-]+'
+    ConstraintDescription: Should match the role name regex
+    MinLength: 1
+    MaxLength: 64
+
 Metadata:
   Source: https://github.com/mozilla/cloudformation-cross-account-outputs
   TemplateVersion: 4.0.0
-Mappings:
-  Variables:
-    DynamoDBTable:
-      Name: cloudformation-stack-emissions
-      Region: us-west-2
-    IAMRole:
-      Name: cloudformation-sns-emission-consumer
+
 Resources:
   CloudFormationEmissionSNSTopic:
     Type: AWS::SNS::Topic
     Properties:
-      TopicName: cloudformation-stack-emissions
+      TopicName: !Ref EmissionSNSTopicName
+
   CloudFormationEmissionSNSTopicPolicy:
     Type: AWS::SNS::TopicPolicy
     Properties:
@@ -30,99 +62,98 @@ Resources:
             Effect: Allow
       Topics:
       - !Ref CloudFormationEmissionSNSTopic
+  
   ProcessCloudFormationSNSEmissionLambdaFunction:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        ZipFile: !Sub
-          - |
-            import cfnresponse
-            import boto3, secrets, string, traceback, json
-            from datetime import datetime
+        ZipFile: !Sub >
+          import cfnresponse
+          import boto3, secrets, string, traceback, json
+          from datetime import datetime
 
-            LAST_UPDATED_KEY = 'last-updated'
-            ACCOUNT_ID_KEY = 'aws-account-id'
-            STACK_ID_KEY = 'stack-id'
-            LOGICAL_RESOURCE_ID_KEY = 'logical-resource-id'
-            SORT_KEY = 'id'
-            CATEGORY_KEY = 'category'
-            GENERAL_ITEM_CATEGORY = 'general'
+          LAST_UPDATED_KEY = 'last-updated'
+          ACCOUNT_ID_KEY = 'aws-account-id'
+          STACK_ID_KEY = 'stack-id'
+          LOGICAL_RESOURCE_ID_KEY = 'logical-resource-id'
+          SORT_KEY = 'id'
+          CATEGORY_KEY = 'category'
+          GENERAL_ITEM_CATEGORY = 'general'
 
-            TABLE_NAME = (
-                'cloudformation-stack-emissions'
-                if '${DynamoDBTableName}'.startswith('$' + '{')
-                else '${DynamoDBTableName}')
-            TABLE_REGION = (
-                'us-west-2'
-                if '${DynamoDBTableRegion}'.startswith('$' + '{')
-                else '${DynamoDBTableRegion}')
-
-
-            def update_table(message):
-                item = dict(message['ResourceProperties'])
-                del(item['ServiceToken'])
-                stack_path = message['StackId'].split(':')[5]
-                stack_guid = stack_path.split('/')[2]
-
-                # Force resources in stacks to only be able to update items that they
-                # created
-                item[ACCOUNT_ID_KEY] = message['StackId'].split(':')[4]
-                item.setdefault(CATEGORY_KEY, GENERAL_ITEM_CATEGORY)
-                item[SORT_KEY] = '{}+{}'.format(
-                    stack_guid,
-                    message['LogicalResourceId'])
-
-                item[STACK_ID_KEY] = stack_guid
-                item[LOGICAL_RESOURCE_ID_KEY] = message['LogicalResourceId']
-
-                item.setdefault('stack-name', stack_path.split('/')[1])
-                item.setdefault('region', message['StackId'].split(':')[3])
-                item.setdefault(LAST_UPDATED_KEY, datetime.utcnow().isoformat() + 'Z')
-
-                dynamodb = boto3.resource('dynamodb', region_name=TABLE_REGION)
-
-                if message['RequestType'] == 'Delete':
-                    table = dynamodb.Table(TABLE_NAME)
-                    table.delete_item(
-                        Key={ACCOUNT_ID_KEY: item[ACCOUNT_ID_KEY],
-                             SORT_KEY: item[SORT_KEY]})
-                    # We don't check to see if the table is now empty and can be deleted
-                    # because there's no cheap or easy way to determine if a table is empty
-                    # using either ItemCount or Scan
-                elif message['RequestType'] in ['Create', 'Update']:
-                    table = dynamodb.Table(TABLE_NAME)
-                    table.put_item(Item=item)
+          TABLE_NAME = (
+              'cloudformation-stack-emissions'
+              if '${DynamoDBTableName}'.startswith('$' + '{')
+              else '${DynamoDBTableName}')
+          TABLE_REGION = (
+              'us-west-2'
+              if '${DynamoDBTableRegion}'.startswith('$' + '{')
+              else '${DynamoDBTableRegion}')
 
 
-            def handler(event, context):
-                message = always_succeed = None
-                try:
-                    for record in event['Records']:
-                        message = json.loads(record['Sns']['Message'])
-                        always_succeed = message['RequestType'] == 'Delete'
-                        update_table(message)
-                except Exception:
-                    print('Custom resource failed. Exception: {0}\n{1}'.format(
-                        traceback.format_exc(), event))
-                    status = cfnresponse.SUCCESS if always_succeed else cfnresponse.FAILED
-                else:
-                    print('Custom resource succeeded.')
-                    status = cfnresponse.SUCCESS
-                if 'PhysicalResourceId' in message:
-                    physical_id = message['PhysicalResourceId']
-                else:
-                    random_string = ''.join(
-                        secrets.choice(string.ascii_uppercase + string.digits)
-                        for _ in range(13))
-                    physical_id = "ProcessCloudFormationSNSEmission-{}".format(
-                        random_string)
-                cfnresponse.send(message, context, status, {}, physical_id)
-          - DynamoDBTableName: !FindInMap [ Variables, DynamoDBTable, Name ]
-            DynamoDBTableRegion: !FindInMap [ Variables, DynamoDBTable, Region ]
+          def update_table(message):
+              item = dict(message['ResourceProperties'])
+              del(item['ServiceToken'])
+              stack_path = message['StackId'].split(':')[5]
+              stack_guid = stack_path.split('/')[2]
+
+              # Force resources in stacks to only be able to update items that they
+              # created
+              item[ACCOUNT_ID_KEY] = message['StackId'].split(':')[4]
+              item.setdefault(CATEGORY_KEY, GENERAL_ITEM_CATEGORY)
+              item[SORT_KEY] = '{}+{}'.format(
+                  stack_guid,
+                  message['LogicalResourceId'])
+
+              item[STACK_ID_KEY] = stack_guid
+              item[LOGICAL_RESOURCE_ID_KEY] = message['LogicalResourceId']
+
+              item.setdefault('stack-name', stack_path.split('/')[1])
+              item.setdefault('region', message['StackId'].split(':')[3])
+              item.setdefault(LAST_UPDATED_KEY, datetime.utcnow().isoformat() + 'Z')
+
+              dynamodb = boto3.resource('dynamodb', region_name=TABLE_REGION)
+
+              if message['RequestType'] == 'Delete':
+                  table = dynamodb.Table(TABLE_NAME)
+                  table.delete_item(
+                      Key={ACCOUNT_ID_KEY: item[ACCOUNT_ID_KEY],
+                            SORT_KEY: item[SORT_KEY]})
+                  # We don't check to see if the table is now empty and can be deleted
+                  # because there's no cheap or easy way to determine if a table is empty
+                  # using either ItemCount or Scan
+              elif message['RequestType'] in ['Create', 'Update']:
+                  table = dynamodb.Table(TABLE_NAME)
+                  table.put_item(Item=item)
+
+
+          def handler(event, context):
+              message = always_succeed = None
+              try:
+                  for record in event['Records']:
+                      message = json.loads(record['Sns']['Message'])
+                      always_succeed = message['RequestType'] == 'Delete'
+                      update_table(message)
+              except Exception:
+                  print('Custom resource failed. Exception: {0}\n{1}'.format(
+                      traceback.format_exc(), event))
+                  status = cfnresponse.SUCCESS if always_succeed else cfnresponse.FAILED
+              else:
+                  print('Custom resource succeeded.')
+                  status = cfnresponse.SUCCESS
+              if 'PhysicalResourceId' in message:
+                  physical_id = message['PhysicalResourceId']
+              else:
+                  random_string = ''.join(
+                      secrets.choice(string.ascii_uppercase + string.digits)
+                      for _ in range(13))
+                  physical_id = "ProcessCloudFormationSNSEmission-{}".format(
+                      random_string)
+              cfnresponse.send(message, context, status, {}, physical_id)
       Handler: index.handler
       Runtime: python3.6
-      Role: !Join [ '', [ 'arn:aws:iam::', !Ref 'AWS::AccountId', ':role/', !FindInMap [ Variables, IAMRole, Name ] ]]
+      Role: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${EmissionSNSConsumerIAMRoleName}'
       Timeout: 20
+  
   ProcessCloudFormationSNSEmissionLambdaFunctionPermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -130,6 +161,7 @@ Resources:
       FunctionName: !GetAtt ProcessCloudFormationSNSEmissionLambdaFunction.Arn
       Principal: sns.amazonaws.com
       SourceArn: !Ref CloudFormationEmissionSNSTopic
+  
   CloudFormationEmissionSNSTopicSubscription:
     Type: AWS::SNS::Subscription
     DependsOn: ProcessCloudFormationSNSEmissionLambdaFunctionPermission

--- a/cloudformation/cloudformation-stack-emissions-dynamodb.yml
+++ b/cloudformation/cloudformation-stack-emissions-dynamodb.yml
@@ -1,39 +1,83 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: DynamoDB used to store CloudFormation stack emissions
+
+Parameters:
+  DynamoDBTableName: 
+    Type: String
+    Description: The name of the emission dynamodb table
+    Default: cloudformation-stack-emissions
+    AllowedPattern: "[A-Za-z0-9._-]+"
+    ConstraintDescription: Only alphanumeric characters, dash, underscores and dot
+    MinLength: 3
+    MaxLength: 255
+
+  DynamoDBAttributeSortKey:
+    Type: String
+    Description: The attribute name used for sorting the table
+    Default: id
+    AllowedPattern: "[A-Za-z0-9._-]+"
+    ConstraintDescription: Only alphanumeric characters, dash, underscores and dot
+    MinLength: 1
+    MaxLength: 255
+
+  DynamoDBAttributeAccountIdKey:
+    Type: String
+    Description: The attribute name that will contain the AWS account ids
+    Default: aws-account-id
+    AllowedPattern: "[A-Za-z0-9._-]+"
+    ConstraintDescription: Only alphanumeric characters, dash, underscores and dot
+    MinLength: 1
+    MaxLength: 255
+
+  DynamoDBAttributeCategoryKey:
+    Type: String
+    Description: The attribute name that will contain the category
+    Default: category
+    AllowedPattern: "[A-Za-z0-9._-]+"
+    ConstraintDescription: Only alphanumeric characters, dash, underscores and dot
+    MinLength: 1
+    MaxLength: 255
+
 Metadata:
   Source: https://github.com/mozilla/cloudformation-cross-account-outputs
   TemplateVersion: 4.0.0
-Mappings:
-  Variables:
-    DynamoDBTable:
-      Name: cloudformation-stack-emissions
-      SortKey: id
-      AccountIdKey: aws-account-id
-      CategoryKey: category
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label: 
+          default: "DynamoDB table configuration"
+        Parameters: 
+          - DynamoDBTableName
+          - DynamoDBAttributeSortKey
+          - DynamoDBAttributeAccountIdKey
+          - DynamoDBAttributeCategoryKey
+    ParameterLabels: 
+      VPCID: 
+        default: "Which VPC should this be deployed to?"
+
 Resources:
   DynamoDBTable:
     Type: AWS::DynamoDB::Table
     Properties:
       AttributeDefinitions:
-        - AttributeName: !FindInMap [ Variables, DynamoDBTable, AccountIdKey ]
+        - AttributeName: !Ref DynamoDBAttributeAccountIdKey
           AttributeType: S
-        - AttributeName: !FindInMap [ Variables, DynamoDBTable, SortKey ]
+        - AttributeName: !Ref DynamoDBAttributeSortKey
           AttributeType: S
-        - AttributeName: !FindInMap [ Variables, DynamoDBTable, CategoryKey ]
+        - AttributeName: !Ref DynamoDBAttributeCategoryKey
           AttributeType: S
       BillingMode: PAY_PER_REQUEST
       KeySchema:
         - KeyType: HASH
-          AttributeName: !FindInMap [ Variables, DynamoDBTable, AccountIdKey ]
+          AttributeName: !Ref DynamoDBAttributeAccountIdKey
         - KeyType: RANGE
-          AttributeName: !FindInMap [ Variables, DynamoDBTable, SortKey ]
-      TableName: !FindInMap [ Variables, DynamoDBTable, Name ]
+          AttributeName: !Ref DynamoDBAttributeSortKey
+      TableName: !Ref DynamoDBTableName
       GlobalSecondaryIndexes:
-        - IndexName: !FindInMap [ Variables, DynamoDBTable, CategoryKey ]
+        - IndexName: !Ref DynamoDBAttributeCategoryKey
           KeySchema:
             - KeyType: HASH
-              AttributeName: !FindInMap [ Variables, DynamoDBTable, CategoryKey ]
+              AttributeName: !Ref DynamoDBAttributeCategoryKey
             - KeyType: RANGE
-              AttributeName: !FindInMap [ Variables, DynamoDBTable, SortKey ]
+              AttributeName: !Ref DynamoDBAttributeSortKey
           Projection:
             ProjectionType: ALL

--- a/cloudformation/cloudformation-stack-emissions-dynamodb.yml
+++ b/cloudformation/cloudformation-stack-emissions-dynamodb.yml
@@ -50,9 +50,6 @@ Metadata:
           - DynamoDBAttributeSortKey
           - DynamoDBAttributeAccountIdKey
           - DynamoDBAttributeCategoryKey
-    ParameterLabels: 
-      VPCID: 
-        default: "Which VPC should this be deployed to?"
 
 Resources:
   DynamoDBTable:
@@ -81,3 +78,9 @@ Resources:
               AttributeName: !Ref DynamoDBAttributeSortKey
           Projection:
             ProjectionType: ALL
+
+Outputs: 
+  # Adding the table name as output is very useful to include this 
+  # template as a nested stack.
+  DynamoDBTableName:
+    Value: !Ref DynamoDBTableName


### PR DESCRIPTION
This PR will allow to change the DynamoDB names directly from the CloudFormation parameters. I see multiple advantages to that:
- The user will be able to comply with his own naming convention
- You can reference a central template in multiple deployments (you can before but not in the same account) 
- It is not breaking your actual deployment scripts (as the default values remain the same) 
