### PR TITLE
Fix corrupted Lambda code and increase Lambda Python runtime to 3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,82 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [4.1.0] - 2022-12-12
+
+### Changed
+
+- AWS Lambda function to use supported Python 3.9 runtime
+- Parameterize all hard coded CloudFormation template values and add a stack
+  output of `DynamoDBTableName` thanks to [@NitriKx](https://github.com/NitriKx)
+  in [#15](https://github.com/mozilla/cloudformation-cross-account-outputs/pull/15).
+
+### Fixed
+
+- Corrupted Lambda introduced in [#15](https://github.com/mozilla/cloudformation-cross-account-outputs/pull/15)
+
+## [4.0.0] - 2019-01-30
+
+### Changed
+
+- The DynamoDB table schema, modifying the partition key and sort key and 
+  establishing an additional Global Secondary Index. These changes facilitate
+  querying for either the items in a given AWS account or the items with a given 
+  category value. [#11](https://github.com/mozilla/cloudformation-cross-account-outputs/pull/11)
+
+## [3.0.0] - 2019-01-23
+
+### Added
+
+- Support for a stack to have multiple resources that emit data and for a single
+  stack to produce multiple records in DynamoDB. [#9](https://github.com/mozilla/cloudformation-cross-account-outputs/pull/9)
+- New Makefile targets for more granular control when deploying CloudFormation
+  stacks. [#9](https://github.com/mozilla/cloudformation-cross-account-outputs/pull/9)
+
+### Changed
+
+- The DynamoDB table schema, changing the partition key from account ID to stack
+  ID and the sort key from stack ID to logical resource ID so that each resource
+  within a given CloudFormation stack has unique rights to edit/delete the 
+  attributes it sets. [#9](https://github.com/mozilla/cloudformation-cross-account-outputs/pull/9)
+
+## [2.0.0] - 2019-01-11
+
+### Added
+
+- A Makefile. [#8](https://github.com/mozilla/cloudformation-cross-account-outputs/pull/8)
+- Support for more than one region [#6](https://github.com/mozilla/cloudformation-cross-account-outputs/pull/6)
+- Documentation [#4](https://github.com/mozilla/cloudformation-cross-account-outputs/pull/4)
+
+### Changed
+
+- The DynamoDB schema to prevent multiple stacks in the same account from 
+  overwriting each other. Originally this was intentional in the design but 
+  after working through trying to use it, it became apparent that it wasn't 
+  ideal. [#6](https://github.com/mozilla/cloudformation-cross-account-outputs/pull/6)
+
+### Fixed
+
+- PhysicalResourceId so that the Lambda function checks for the presense of a 
+  PhysicalResourceId in the message and uses that if it's present instead of 
+  generating one.  [#7](https://github.com/mozilla/cloudformation-cross-account-outputs/pull/7)
+
+## [1.0.0] - 2018-12-20
+
+## Added
+
+- Last updated field in output records [#4](https://github.com/mozilla/cloudformation-cross-account-outputs/pull/4)
+- The initial commit. [#2](https://github.com/mozilla/cloudformation-cross-account-outputs/pull/2)
+
+
+[Unreleased]: https://github.com/mozilla/cloudformation-cross-account-outputs/compare/v4.1.0...HEAD
+[4.1.0]: https://github.com/mozilla/cloudformation-cross-account-outputs/v4.0.0...v4.1.0
+[4.0.0]: https://github.com/mozilla/cloudformation-cross-account-outputs/compare/v3.0.0...v4.0.0
+[3.0.0]: https://github.com/mozilla/cloudformation-cross-account-outputs/compare/v2.0.0...v3.0.0
+[2.0.0]: https://github.com/mozilla/cloudformation-cross-account-outputs/compare/v1.0.0...v2.0.0
+[1.0.0]: https://github.com/mozilla/cloudformation-cross-account-outputs/releases/tag/v1.0.0

--- a/cloudformation/cloudformation-sns-emission-consumer-role.yml
+++ b/cloudformation/cloudformation-sns-emission-consumer-role.yml
@@ -29,6 +29,7 @@ Parameters:
 
 Metadata:
   Source: https://github.com/mozilla/cloudformation-cross-account-outputs
+  TemplateVersion: 4.1.0
 
 Resources:
   ProcessCloudFormationSNSEmissionLambdaIAMRole:

--- a/cloudformation/cloudformation-sns-emission-consumer.yml
+++ b/cloudformation/cloudformation-sns-emission-consumer.yml
@@ -150,7 +150,7 @@ Resources:
                       random_string)
               cfnresponse.send(message, context, status, {}, physical_id)
       Handler: index.handler
-      Runtime: python3.6
+      Runtime: python3.9
       Role: !Sub 'arn:aws:iam::${AWS::AccountId}:role/${EmissionSNSConsumerIAMRoleName}'
       Timeout: 20
   

--- a/cloudformation/cloudformation-sns-emission-consumer.yml
+++ b/cloudformation/cloudformation-sns-emission-consumer.yml
@@ -67,7 +67,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        ZipFile: !Sub >
+        ZipFile: !Sub |
           import cfnresponse
           import boto3, secrets, string, traceback, json
           from datetime import datetime

--- a/cloudformation/cloudformation-sns-emission-consumer.yml
+++ b/cloudformation/cloudformation-sns-emission-consumer.yml
@@ -39,7 +39,7 @@ Parameters:
 
 Metadata:
   Source: https://github.com/mozilla/cloudformation-cross-account-outputs
-  TemplateVersion: 4.0.0
+  TemplateVersion: 4.1.0
 
 Resources:
   CloudFormationEmissionSNSTopic:

--- a/cloudformation/cloudformation-stack-emissions-dynamodb.yml
+++ b/cloudformation/cloudformation-stack-emissions-dynamodb.yml
@@ -40,7 +40,7 @@ Parameters:
 
 Metadata:
   Source: https://github.com/mozilla/cloudformation-cross-account-outputs
-  TemplateVersion: 4.0.0
+  TemplateVersion: 4.1.0
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label: 


### PR DESCRIPTION
* Add a CHANGELOG
* Update AWS Lambda Python runtime to 3.9
  * Fixes #18
* Fix corrupted Lambda
  * Fixes #19 by changing the YAML interpretation of the Lambda function back to "literal" block [1] instead of "folded" block [2].
  * This bug was introduced in #15

[1]: https://yaml.org/spec/1.2.2/#812-literal-style
[2]: https://yaml.org/spec/1.2.2/#813-folded-style
